### PR TITLE
Reduce max_hear_distance

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -22,7 +22,7 @@ minetest.register_globalstep(function(dtime)
 									inv:add_item("main", ItemStack(object:get_luaentity().itemstring))
 									minetest.sound_play("item_drop_pickup", {
 										pos = pos,
-										max_hear_distance = 100,
+										max_hear_distance = 15,
 										gain = 10.0,
 									})
 									object:get_luaentity().itemstring = ""


### PR DESCRIPTION
At max hear distance 100, item pickups can be heard by other players from unreasonably far away. Something in the range of 15~20 seems more appropriate.